### PR TITLE
Board and Cell React refactor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,11 +10,11 @@ class App extends Component {
   constructor(props) {
     super(props);
 
-    this.renderCell = this.renderCell.bind(this);
     this.handleClick = this.handleClick.bind(this);
     this.resetGame = this.resetGame.bind(this);
     this.endGame = this.endGame.bind(this);
     this.placePiece = this.placePiece.bind(this);
+    this.handleClick = this.handleClick.bind(this);
 
     this.state = {
       gameState: 'notFinished',
@@ -63,16 +63,6 @@ class App extends Component {
     });
   }
 
-  renderCell(x, y) {
-    const { gameBoard } = this.state;
-    return (
-      <Cell
-        value={gameBoard[x][y]}
-        handleClick={() => this.handleClick(x, y)}
-      />
-    );
-  }
-
   resetGame() {
     this.setState({
       gameState: 'notFinished',
@@ -87,7 +77,8 @@ class App extends Component {
         <Board
           nextPiece={this.state.nextPiece}
           gameState={this.state.gameState}
-          renderCell={this.renderCell}
+          gameBoard={this.state.gameBoard}
+          handleClick={this.handleClick}
           resetGame={this.resetGame}
         />
       </div>

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -21,21 +21,22 @@ const Board = ({
       <div>
         {gameStatus}
       </div>
-      <div className='row-1'>
-        <Cell value={gameBoard[0][0]} handleClick={handleClick} x={0} y={0} />
-        <Cell value={gameBoard[0][1]} handleClick={handleClick} x={0} y={1} />
-        <Cell value={gameBoard[0][2]} handleClick={handleClick} x={0} y={2} />
-      </div>
-      <div className='row-2'>
-        <Cell value={gameBoard[1][0]} handleClick={handleClick} x={1} y={0} />
-        <Cell value={gameBoard[1][1]} handleClick={handleClick} x={1} y={1} />
-        <Cell value={gameBoard[1][2]} handleClick={handleClick} x={1} y={2} />
-      </div>
-      <div className='row-3'>
-        <Cell value={gameBoard[2][0]} handleClick={handleClick} x={2} y={0} />
-        <Cell value={gameBoard[2][1]} handleClick={handleClick} x={2} y={1} />
-        <Cell value={gameBoard[2][2]} handleClick={handleClick} x={2} y={2} />
-      </div>
+      {gameBoard.map((gameRow, index) => {
+        return (
+          <div className={`row-${index}`}>
+            {gameRow.map((cell, index2) => {
+              return (
+                <Cell
+                  value={gameBoard[index][index2]}
+                  handleClick={handleClick}
+                  x={index}
+                  y={index2}
+                />
+              );
+            })}
+          </div>
+        );
+      })}
       <button type='button' onClick={resetGame}>
         Reset The Game
       </button>

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
+import Cell from './Cell';
+
 const Board = ({
-  renderCell,
   nextPiece,
-  resetGame,
   gameState,
+  gameBoard,
+  handleClick,
+  resetGame,
 }) => {
   let gameStatus;
   if (gameState === 'notFinished') {
@@ -19,19 +22,19 @@ const Board = ({
         {gameStatus}
       </div>
       <div className='row-1'>
-        {renderCell(0, 0)}
-        {renderCell(0, 1)}
-        {renderCell(0, 2)}
+        <Cell value={gameBoard[0][0]} handleClick={handleClick} x={0} y={0} />
+        <Cell value={gameBoard[0][1]} handleClick={handleClick} x={0} y={1} />
+        <Cell value={gameBoard[0][2]} handleClick={handleClick} x={0} y={2} />
       </div>
       <div className='row-2'>
-        {renderCell(1, 0)}
-        {renderCell(1, 1)}
-        {renderCell(1, 2)}
+        <Cell value={gameBoard[1][0]} handleClick={handleClick} x={1} y={0} />
+        <Cell value={gameBoard[1][1]} handleClick={handleClick} x={1} y={1} />
+        <Cell value={gameBoard[1][2]} handleClick={handleClick} x={1} y={2} />
       </div>
       <div className='row-3'>
-        {renderCell(2, 0)}
-        {renderCell(2, 1)}
-        {renderCell(2, 2)}
+        <Cell value={gameBoard[2][0]} handleClick={handleClick} x={2} y={0} />
+        <Cell value={gameBoard[2][1]} handleClick={handleClick} x={2} y={1} />
+        <Cell value={gameBoard[2][2]} handleClick={handleClick} x={2} y={2} />
       </div>
       <button type='button' onClick={resetGame}>
         Reset The Game

--- a/src/Cell.jsx
+++ b/src/Cell.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
-const Cell = ({ value, handleClick }) => (
-  <button type='button' className='cell' onClick={handleClick}>
+const Cell = ({
+  value,
+  handleClick,
+  x,
+  y,
+}) => (
+  <button type='button' className='cell' onClick={() => handleClick(x, y)}>
     {value}
   </button>
 );


### PR DESCRIPTION
The implementation of my original React App loosely followed the implementation as laid out in the React tic-tac-toe tutorial, but that implementation wouldn't have played well with how I want to implement Redux.  So, I am refactoring my implementation so it's easier to implement Redux.

I did the following:
- Change Board so that it rendered Cells directly, instead of via the handed-down renderCell method of App
- Change Board so that it renders Cells via a double map function (previously it was done manually)